### PR TITLE
Fixes NPE when auto.create and incorrect access privileges

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/TableDefinitions.java
@@ -83,6 +83,10 @@ public class TableDefinitions {
       TableId tableId
   ) throws SQLException {
     TableDefinition dbTable = dialect.describeTable(connection, tableId);
+    if (dbTable == null) {
+      log.error("Unable to refresh metadata for table {}", tableId);
+      return null;
+    }
     log.info("Refreshing metadata for table {} to {}", tableId, dbTable);
     cache.put(dbTable.id(), dbTable);
     return dbTable;


### PR DESCRIPTION
This is for issue #646.

As per the comment from rhauch, added some simple logic to handle and return null if the dbTable reference in the TableDefinitions.refresh(...) method is null, rather than cause NPE.